### PR TITLE
Fix wrong php5.4 mysql extension

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -144,7 +144,7 @@ manala_skeleton_patterns:
         or manala_skeleton_options.mariadb
       )|ternary(
         {
-          '5.4':['mysql'],
+          '5.4':['mysqlnd'],
           '5.5':['mysqlnd'],
           '5.6':['mysqlnd'],
           '7.0':['mysql']


### PR DESCRIPTION
Since php5.4 mysqlnd is default extension, see http://php.net/manual/en/mysqlinfo.library.choosing.php